### PR TITLE
return error if contrib repository not set

### DIFF
--- a/minicli
+++ b/minicli
@@ -10,12 +10,19 @@ require __DIR__ . '/vendor/autoload.php';
 use Minicli\App;
 use Minicli\Curly\Client;
 
+$contribRepository = getenv('CONTRIB_REPOSITORY');
+
 $app = new App([
     'app_path' => __DIR__ . '/app/Command',
-    'repository' => getenv('CONTRIB_REPOSITORY') ?: 'minicli/minicli',
+    'repository' => $contribRepository,
     'output_file' => getenv('CONTRIB_OUTPUT_FILE') ?: 'CONTRIBUTORS.md',
     'ignore_users' => [ 'github-actions[bot]' ]
 ]);
+
+if (null === $contribRepository) {
+    $app->getPrinter()->error("CONTRIB_REPOSITORY not set.");
+    return 1;
+}
 
 $app->registerCommand('update-contributors', function () use ($app) {
     $app->getPrinter()->info('Fetching top contributors...');


### PR DESCRIPTION
I created this PR because if you don't set the `CONTRIB_REPOSITORY` or you create a wrong workflow file, this tool uses the default `minicli/minicli` and you can create/edit the contributors file with the wrong data.
(it happens to me in an open-source library).

What do you think?